### PR TITLE
[eslint-config-namoo] Fix react-hooks lint

### DIFF
--- a/libs/eslint-config-namoo/configs/react.js
+++ b/libs/eslint-config-namoo/configs/react.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { fixupConfigRules } from "@eslint/compat";
 import { FlatCompat } from "@eslint/eslintrc";
 import reactRefreshPlugin from "eslint-plugin-react-refresh";
 
@@ -7,7 +8,7 @@ const rc = new FlatCompat();
 
 /** @type {import("@typescript-eslint/utils").TSESLint.FlatConfig.ConfigArray} */
 export default [
-  ...rc.extends("plugin:react-hooks/recommended"),
+  ...fixupConfigRules(rc.extends("plugin:react-hooks/recommended")),
   {
     plugins: {
       "react-refresh": reactRefreshPlugin,


### PR DESCRIPTION
## Summary

Fix react-hooks lint

## Description

- Make react-hooks lint compatible with eslint 9.
